### PR TITLE
Show dock only when the mouse is above it

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -121,6 +121,16 @@ class Extension {
     }
 
     _on_screen_border_box_hover() {
+        let [pointerX, pointerY] = global.get_pointer();
+    	let halfscreen = Main.layoutManager.getWorkAreaForMonitor(0).width/2;
+        
+        if(pointerX > (halfscreen + this.dock._box.width/2 + 10)){
+            return;
+        }        
+        else if(pointerX < (halfscreen - this.dock._box.width/2 - 10)){
+            return;
+        }
+        
         if (!this.dock.is_visible() && !Main.overview.visible && !Main.sessionMode.isLocked) {
             if (!global.display.get_focus_window() || !global.display.get_focus_window().is_fullscreen()) {
                 this.show_dock_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, SHOW_DOCK_DELAY, () => {


### PR DESCRIPTION
Normally when you put the cursor in the bottom, even if it is at the corners, the dock will show. With this commit it will show up only if the cursor is above the dock area.

https://user-images.githubusercontent.com/78305798/152234517-05cb7841-f2be-427f-809e-51e0d439474e.mp4


