### PR TITLE
fixed dock shift after entering the overview

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -101,7 +101,7 @@ class Extension {
         }
 
         this.max_dock_height = Math.round(this.work_area.height * DASH_MAX_HEIGHT_RATIO);
-        this.dock.set_width(this.work_area.width - 48);
+        this.dock.set_width(this.work_area.width);
         this.dock.set_height(Math.min(this.dock.get_preferred_height(this.work_area.width), this.max_dock_height));
         this.dock.setMaxSize(this.dock.width, this.max_dock_height);
         this.dock.set_position(this.work_area.x, this.work_area.y + this.work_area.height);


### PR DESCRIPTION
### Before
![before-fix-dock-shift](https://user-images.githubusercontent.com/48316573/158280799-0f200f48-aba4-4ec3-9fcf-7e732c0dbcdc.gif)
### After
![after-fix-dock-shift](https://user-images.githubusercontent.com/48316573/158280804-e30cf295-ec85-476a-bd36-7f916011ce9e.gif)

`Tested with GNOME Shell 41.4`