### PR TITLE
fix: do not include hidden windows

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -166,18 +166,19 @@ class Extension {
                 this.app.open_new_window(-1);
                 Main.overview.hide();
             } else {
-                switch (this.app.get_n_windows()) {
+                let windows = this.app.get_windows().filter(window => !window.is_override_redirect());
+                switch (windows.length) {
                     case 0:
                         this.app.activate();
                         Main.overview.hide();
                     break;
                     case 1:
-                        if (this.app.get_windows()[0].has_focus() && this.app.get_windows()[0].can_minimize()) {
-                            this.app.get_windows()[0].minimize();
+                        if (windows[0].has_focus() && windows[0].can_minimize()) {
+                           windows[0].minimize();
                             Main.overview.hide();
                         } else {
-                            if (!this.app.get_windows()[0].has_focus()) {
-                                this.app.get_windows()[0].activate(global.get_current_time());
+                            if (!windows[0].has_focus()) {
+                                windows[0].activate(global.get_current_time());
                                 Main.overview.hide();
                             }
                         }


### PR DESCRIPTION
For some reason and apparently only using X11, apps like Firefox and Chromium opens a hidden window (and is not considered hidden but "Override-Redirect Window") that you can't see in "Activities" but it's counting. I don't know if this is the best way to solve it but it works.

