### PR TITLE
Don't include attached dialogs

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -166,7 +166,7 @@ class Extension {
                 this.app.open_new_window(-1);
                 Main.overview.hide();
             } else {
-                let windows = this.app.get_windows().filter(window => !window.is_override_redirect());
+                let windows = this.app.get_windows().filter(window => !window.is_override_redirect() && !window.is_attached_dialog());
                 switch (windows.length) {
                     case 0:
                         this.app.activate();


### PR DESCRIPTION
When a window has a dialog clicking its icon on the dock opens the Activities overview instead of focus/minimize the window.

[https://i.nuuls.com/JiMni.mp4](https://i.nuuls.com/JiMni.mp4)