### PR TITLE
Add preference to show overview at startup

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -298,7 +298,9 @@ class Extension {
         this._create_dock();
 
         this.startup_complete = Main.layoutManager.connect('startup-complete', () => {
-            Main.overview.hide();
+            if (!settings.get_boolean('show-overview')) {
+                Main.overview.hide();
+            }
         });
     }
 

--- a/org.gnome.shell.extensions.dock-from-dash.gschema.xml
+++ b/org.gnome.shell.extensions.dock-from-dash.gschema.xml
@@ -51,5 +51,11 @@
         <description>Duration, in milliseconds, of dock hiding animation.</description>
     </key>
 
+    <key type="b" name="show-overview">
+        <default>false</default>
+        <summary>Show overview at startup</summary>
+        <description>Show the overview at startup.</description>
+    </key>
+
     </schema>
 </schemalist>

--- a/prefs.js
+++ b/prefs.js
@@ -49,6 +49,9 @@ function buildPrefsWidget() {
     let hideDockDuration = buildSpinButton('hide-dock-duration',_("Duration of dock hiding animation (ms)"), 0, 1000, 50);
     frame.append(hideDockDuration);
 
+    let showOverview = buildSwitcher('show-overview',_("Show overview at startup"));
+    frame.append(showOverview);
+
     frame.show();
     return frame;
 }

--- a/schemas/org.gnome.shell.extensions.dock-from-dash.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dock-from-dash.gschema.xml
@@ -51,5 +51,11 @@
         <description>Duration, in milliseconds, of dock hiding animation.</description>
     </key>
 
+    <key type="b" name="show-overview">
+        <default>false</default>
+        <summary>Show overview at startup</summary>
+        <description>Show the overview at startup.</description>
+    </key>
+
     </schema>
 </schemalist>


### PR DESCRIPTION
Add a GSetting key, 'show-overview' that can be toggled true or false by a UI switch. This value is checked during the extension `enable` function when adding the startup-complete signal handler. The handler function checks the value of `show-overview` and conditionally hides the overview based on the value of this setting.

Fixes: #64