### PR TITLE
Add gnome-shell 43.x compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/fthx/dock-from-dash",
   "uuid": "dock-from-dash@fthx",


### PR DESCRIPTION
No additional changes seem to be required