### PR TITLE
Increase show dock trigger area, fix #81

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,7 +15,7 @@ const AppDisplay = imports.ui.appDisplay;
 const WorkspaceManager = global.workspace_manager;
 
 var DASH_MAX_HEIGHT_RATIO = 15;
-var SHOW_DOCK_BOX_HEIGHT = 2;
+var SHOW_DOCK_BOX_HEIGHT = 20;
 
 var settings;
 


### PR DESCRIPTION
See https://github.com/fthx/dock-from-dash/issues/81. The setting:
```js
var SHOW_DOCK_BOX_HEIGHT = 20;
```
works for me but I don't know whether it is okay for other people. Thank you!