### PR TITLE
Add german translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,3 +1,4 @@
+de
 es
 fr
 nl

--- a/po/de.po
+++ b/po/de.po
@@ -1,55 +1,54 @@
-# Dutch translations for dock-from-dash package.
-# Copyright (C) 2022 THE dock-from-dash'S COPYRIGHT HOLDER
+# German translations for dock-from-dash package.
+# Copyright (C) 2023 THE dock-from-dash'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the dock-from-dash package.
-# Automatically generated, 2022.
+# Automatically generated, 2023.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-04-17 15:48+0000\n"
-"PO-Revision-Date: 2022-06-27 14:31+0200\n"
-"Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
-"Language-Team: Dutch <gnome-nl-list@gnome.org>\n"
-"Language: nl\n"
+"PO-Revision-Date: 2023-04-17 15:48+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1\n"
 
 #: prefs.js:28
 msgid "Show overview at startup"
-msgstr ""
+msgstr "Übersicht beim Starten anzeigen"
 
 #: prefs.js:31
 msgid "Always show the dock"
-msgstr "Dock altijd weergeven"
+msgstr "Das Dock immer anzeigen"
 
 #: prefs.js:34
 msgid "Show dock in full screen mode"
-msgstr "Dock tijdens volledig scherm weergeven"
+msgstr "Dock im Vollbildmodus anzeigen"
 
 #: prefs.js:37
 msgid "Dock background opacity (%)"
-msgstr "Ondoorzichtigheid van dock-achtergrond (%)"
+msgstr "Deckkraft des Dock-Hintergrunds (%)"
 
 #: prefs.js:40
 msgid "Dock icons opacity (%)"
-msgstr "Ondoorzichtigheid van dock-pictogrammen (%)"
+msgstr "Deckkraft der Dock-Symbole (%)"
 
 #: prefs.js:43
 msgid "Delay for dock autohide (ms)"
-msgstr "Vertraging voor verbergen van dock (ms)"
+msgstr "Verzögerung für das automatische Ausblenden des Docks (ms)"
 
 #: prefs.js:46
 msgid "Delay for dock showing (ms)"
-msgstr "Vertraging voor tonen van dock (ms)"
+msgstr "Verzögerung für das Anzeigen des Docks (ms)"
 
 #: prefs.js:49
 msgid "Duration of dock showing animation (ms)"
-msgstr "Lengte van toonanimatie van dock (ms)"
+msgstr "Dauer der Animation zum Einblenden des Docks (ms)"
 
 #: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
-msgstr "Lengte van verberganimatie van dock (ms)"
+msgstr "Dauer der Animation zum Ausblenden des Docks (ms)"

--- a/po/dock-from-dash.pot
+++ b/po/dock-from-dash.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-27 14:23+0200\n"
+"POT-Creation-Date: 2023-04-17 15:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,33 +18,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: prefs.js:28
-msgid "Always show the dock"
+msgid "Show overview at startup"
 msgstr ""
 
 #: prefs.js:31
-msgid "Show dock in full screen mode"
+msgid "Always show the dock"
 msgstr ""
 
 #: prefs.js:34
-msgid "Dock background opacity (%)"
+msgid "Show dock in full screen mode"
 msgstr ""
 
 #: prefs.js:37
-msgid "Dock icons opacity (%)"
+msgid "Dock background opacity (%)"
 msgstr ""
 
 #: prefs.js:40
-msgid "Delay for dock autohide (ms)"
+msgid "Dock icons opacity (%)"
 msgstr ""
 
 #: prefs.js:43
-msgid "Delay for dock showing (ms)"
+msgid "Delay for dock autohide (ms)"
 msgstr ""
 
 #: prefs.js:46
-msgid "Duration of dock showing animation (ms)"
+msgid "Delay for dock showing (ms)"
 msgstr ""
 
 #: prefs.js:49
+msgid "Duration of dock showing animation (ms)"
+msgstr ""
+
+#: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-01 15:09+0200\n"
+"POT-Creation-Date: 2023-04-17 15:48+0000\n"
 "PO-Revision-Date: 2022-03-31 13:44+0200\n"
 "Last-Translator: Sergio Costas <rastersoft@gmail.com>\n"
 "Language-Team: Español; Castellano <rastersoft@gmail.com>\n"
@@ -20,34 +20,38 @@ msgstr ""
 "X-Generator: Gtranslator 41.0\n"
 
 #: prefs.js:28
-msgid "Always show the dock"
+msgid "Show overview at startup"
 msgstr ""
 
 #: prefs.js:31
+msgid "Always show the dock"
+msgstr ""
+
+#: prefs.js:34
 msgid "Show dock in full screen mode"
 msgstr "Mostrar el dock en modo de pantalla completa"
 
-#: prefs.js:34
+#: prefs.js:37
 msgid "Dock background opacity (%)"
 msgstr "Opacidad del fondo del dock (%)"
 
-#: prefs.js:37
+#: prefs.js:40
 msgid "Dock icons opacity (%)"
 msgstr "Opacidad de los iconos en el dock (%)"
 
-#: prefs.js:40
+#: prefs.js:43
 msgid "Delay for dock autohide (ms)"
 msgstr "Retardo para autoocultamiento del dock"
 
-#: prefs.js:43
+#: prefs.js:46
 msgid "Delay for dock showing (ms)"
 msgstr "Retardo antes de mostrar el dock (ms)"
 
-#: prefs.js:46
+#: prefs.js:49
 msgid "Duration of dock showing animation (ms)"
 msgstr "Duración de la animación de mostrar el dock (ms)"
 
-#: prefs.js:49
+#: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
 msgstr "Duración de la animación de ocultar el dock (ms)"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-01 15:09+0200\n"
+"POT-Creation-Date: 2023-04-17 15:48+0000\n"
 "PO-Revision-Date: 2022-09-11 08:42+0300\n"
 "Last-Translator: Aki <dev.ackky200r@gmail.com>\n"
 "Language-Team: Finnish <none>\n"
@@ -20,34 +20,38 @@ msgstr ""
 "X-Generator: Gtranslator 40.0\n"
 
 #: prefs.js:28
+msgid "Show overview at startup"
+msgstr ""
+
+#: prefs.js:31
 msgid "Always show the dock"
 msgstr "Näytä telakka aina"
 
-#: prefs.js:31
+#: prefs.js:34
 msgid "Show dock in full screen mode"
 msgstr "Näytä telakka koko näytön tilassa"
 
-#: prefs.js:34
+#: prefs.js:37
 msgid "Dock background opacity (%)"
 msgstr "Telakan taustan peittävyys (%)"
 
-#: prefs.js:37
+#: prefs.js:40
 msgid "Dock icons opacity (%)"
 msgstr "Telakan kuvakkeiden peittävyys (%)"
 
-#: prefs.js:40
+#: prefs.js:43
 msgid "Delay for dock autohide (ms)"
 msgstr "Telakan automaattisen piilotuksen viive (ms)"
 
-#: prefs.js:43
+#: prefs.js:46
 msgid "Delay for dock showing (ms)"
 msgstr "Telakan automaattisen ilmestymisen viive (ms)"
 
-#: prefs.js:46
+#: prefs.js:49
 msgid "Duration of dock showing animation (ms)"
 msgstr "Telakan ilmestymisen animoinnin kesto (ms)"
 
-#: prefs.js:49
+#: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
 msgstr "Telakan piilotuksen animoinnin kesto (ms)"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-01 15:09+0200\n"
+"POT-Creation-Date: 2023-04-17 15:48+0000\n"
 "PO-Revision-Date: 2022-04-01 15:09+0200\n"
 "Last-Translator: Francois THIRIOUX <thirioux@gmail.com>\n"
 "Language-Team: French <thirioux@gmail.com>\n"
@@ -20,34 +20,38 @@ msgstr ""
 "X-Generator: Gtranslator 41.0\n"
 
 #: prefs.js:28
+msgid "Show overview at startup"
+msgstr ""
+
+#: prefs.js:31
 msgid "Always show the dock"
 msgstr "Montrer le dock en permanence"
 
-#: prefs.js:31
+#: prefs.js:34
 msgid "Show dock in full screen mode"
 msgstr "Montrer en mode plein écran"
 
-#: prefs.js:34
+#: prefs.js:37
 msgid "Dock background opacity (%)"
 msgstr "Opacité du fond du dock (%)"
 
-#: prefs.js:37
+#: prefs.js:40
 msgid "Dock icons opacity (%)"
 msgstr "Opacité des icônes du dock (%)"
 
-#: prefs.js:40
+#: prefs.js:43
 msgid "Delay for dock autohide (ms)"
 msgstr "Délai pour le masquage automatique (ms)"
 
-#: prefs.js:43
+#: prefs.js:46
 msgid "Delay for dock showing (ms)"
 msgstr "Délai d'apparition du dock (ms)"
 
-#: prefs.js:46
+#: prefs.js:49
 msgid "Duration of dock showing animation (ms)"
 msgstr "Durée de l'animation d'apparition du dock (ms)"
 
-#: prefs.js:49
+#: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
 msgstr "Durée de l'animation du masquage du dock (ms)"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dock-from-dash\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-14 10:45+0200\n"
+"POT-Creation-Date: 2023-04-17 15:48+0000\n"
 "PO-Revision-Date: 2022-04-01 10:45+0200\n"
 "Last-Translator: K0rtus\n"
 "Language-Team: K0rtus\n"
@@ -20,39 +20,45 @@ msgstr ""
 "X-Generator: Gtranslator 41.0\n"
 
 #: prefs.js:28
+msgid "Show overview at startup"
+msgstr ""
+
+#: prefs.js:31
 msgid "Always show the dock"
 msgstr "Всегда показывать док-бар"
 
-#: prefs.js:31
+#: prefs.js:34
 msgid "Show dock in full screen mode"
 msgstr "Показывать док-бар в полноэкранном режиме"
 
-#: prefs.js:34
+#: prefs.js:37
 msgid "Dock background opacity (%)"
 msgstr "Непрозрачность фона док-бара (%)"
 
-#: prefs.js:37
+#: prefs.js:40
 msgid "Dock icons opacity (%)"
 msgstr "Непрозрачность значков док-бара (%)"
 
-#: prefs.js:40
+#: prefs.js:43
 msgid "Delay for dock autohide (ms)"
 msgstr "Задержка автоматического скрытия док-бара (мс)"
 
-#: prefs.js:43
+#: prefs.js:46
 msgid "Delay for dock showing (ms)"
 msgstr "Задержка показа док-бара (мс)"
 
-#: prefs.js:46
+#: prefs.js:49
 msgid "Duration of dock showing animation (ms)"
 msgstr "Продолжительность анимации показа док-бара (мс)"
 
-#: prefs.js:49
+#: prefs.js:52
 msgid "Duration of dock hiding animation (ms)"
 msgstr "Продолжительность анимации скрытия док-бара (мс)"
 
 #~ msgid "Do not auto hide the dock: screen bottom hover to toggle"
-#~ msgstr "Не скрывать док-бар автоматически: наведите курсор на нижнюю часть экрана, чтобы переключить"
+#~ msgstr ""
+#~ "Не скрывать док-бар автоматически: наведите курсор на нижнюю часть "
+#~ "экрана, чтобы переключить"
 
 #~ msgid "Keep the dock always visible"
 #~ msgstr "Держать док-бар всегда видимым"


### PR DESCRIPTION
I added the german translation. I think the other `*.po` files changed, because I called `ninja -C .build dock-from-dash-update-po`. It seems `msgid "Show overview at startup"` was missing in those files.