### PR TITLE
Support gnome 44 by updating metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/fthx/dock-from-dash",
   "uuid": "dock-from-dash@fthx",


### PR DESCRIPTION
A trivial update that seems to just work.